### PR TITLE
トピック一覧ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'pry-byebug'
 gem 'pry-doc'
 gem 'pry-rails'
+gem 'kaminari'
+gem 'redcarpet'
+gem 'coderay'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -152,6 +164,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     regexp_parser (1.7.1)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
@@ -214,7 +227,9 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  coderay
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug
@@ -222,6 +237,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
+  redcarpet
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,8 @@
 
 main{
   max-width: 1200px;
-  margin: 0 auto;
+  margin: 30px auto;
+
 }
 
 // headerのナビゲーションバーの設定
@@ -23,4 +24,118 @@ main{
 header img{
   width: 100%;
   height: 800px;
+}
+
+
+
+// トピック一覧
+// トピックのリンク
+.topic-list{
+  margin: 60px 0 30px 10px;
+  text-align: center;
+}
+//トピックの１つづつのリンク
+.topic-list .topic_tag{
+  margin: 0 20px;
+  padding: 10px 50px;
+  background-color: #ff8c19;
+  color: white;
+  text-decoration: none;
+}
+// トピックのaタグ
+.topic_content a{
+  text-decoration: none;
+  color: black;
+}
+// トピックのカード
+.topic_content .card{
+  margin: 30px;
+  width: 350px;
+  height: 400px;
+}
+// トピックの画像
+.topic_content #card_image{
+  width: auto;
+  height: 192px;
+}
+// トピックのジャンル
+.topic_content .topic_genre{
+  font-size: 15px;
+  margin: -10px 0 10px -10px;
+}
+// トピックのタイトル
+.topic_content .topic_title{
+  font-size: 20px;
+  font-weight: bold;
+}
+// トピックの店の名前
+.topic_content .topic_shop_name{
+  margin-top: 40px;
+  font-size: 13px;
+}
+// トピックの住所
+.topic_content .topic_address{
+  font-size: 13px;
+}
+// トピックの日付
+.topic_content .topic_day{
+  margin-right: 10px;
+  text-align: right;
+  font-size: 13px;
+}
+// トピックのページネーション
+.topic_page{
+  margin-left: 1050px;
+}
+
+
+
+// トピック詳細
+// トピック詳細の画像（親要素）
+.topic_show .show_image{
+  text-align: center;
+}
+// トピック詳細の画像（子要素）
+.topic_show #top_image{
+  width: 1200px;
+  height: 600px;
+}
+// トピック詳細のお店画像
+.topic_show #show_shop_image{
+  width: 200px;
+  height: 200px;
+}
+// トピック詳細のタイトル
+.topic_show h2 {
+  position: relative;
+  color: white;
+  background: #ff8c19;
+  line-height: 1.4;
+  margin-bottom: 30px;
+  padding: 0.5em 0.5em 0.5em 1.8em;
+}
+.topic_show h2:before {
+  font-family: "Font Awesome 5 Free";
+  content: "\f14a";
+  font-weight: 900;
+  position: absolute;
+  left : 0.5em; /*左端からのアイコンまでの距離*/
+}
+// トピック詳細の店紹介
+.topic_show ul {
+  border: solid 2px #ffb03f;
+  padding: 0.5em 1em 0.5em 2.3em;
+  position: relative;
+}
+.topic_show ul li {
+  line-height: 1.5;
+  padding: 0.5em 0;
+  list-style-type: none!important;/*ポチ消す*/
+}
+.topic_show ul li:before {
+  font-family: "Font Awesome 5 Free";
+  content: "\f00c";
+  position: absolute;
+  left : 1em; /*左端からのアイコンまで*/
+  color: #ffb03f; /*アイコン色*/
 }

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,9 @@
 class HomesController < ApplicationController
   def index
-    @topics = Topic.all
-    @shops = Shop.all
+    @topics = Topic.all.page(params[:page]).per(9)
+  end
+
+  def show
+    @topic = Topic.find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,46 @@
 module ApplicationHelper
+  # マークダウン形式で記入するためにrequire
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+        language = language.split(':')[0]
+
+        case language.to_s
+        when 'rb'
+            lang = 'ruby'
+        when 'yml'
+            lang = 'yaml'
+        when 'css'
+            lang = 'css'
+        when 'html'
+            lang = 'html'
+        when ''
+            lang = 'md'
+        else
+            lang = language
+        end
+
+        CodeRay.scan(code, lang).div
+    end
+  end
+
+  # マークダウンを可能にするメソッド
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(filter_html: true, hard_wrap: true)
+    options = {
+        autolink: true,
+        space_after_headers: true,
+        no_intra_emphasis: true,
+        fenced_code_blocks: true,
+        tables: true,
+        hard_wrap: true,
+        xhtml: true,
+        lax_html_blocks: true,
+        strikethrough: true
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text)
+  end
 end

--- a/app/views/homes/_header.html.erb
+++ b/app/views/homes/_header.html.erb
@@ -4,7 +4,7 @@
     <a href="#">インスタグラム</a>
   </div>
 <nav class="navbar navbar-expand-lg">
-  <a class="navbar-brand" href="#" id="top_title">おのグルメ</a>
+  <a class="navbar-brand" href="/" id="top_title">おのグルメ</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
@@ -35,4 +35,3 @@
   </div>
 </nav>
 </div>
-<img src="assets/DA0EED04-E35D-4E3B-B20F-1A7E2AB6A11D.jpg" alt="画像">

--- a/app/views/homes/_header_image.html.erb
+++ b/app/views/homes/_header_image.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag "DA0EED04-E35D-4E3B-B20F-1A7E2AB6A11D.jpg" %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,1 +1,36 @@
-<h1>HOME</h1>
+<div class="input-group justify-content-center">
+  <input type="text" placeholder="　グルメ探し" style="width:30%;">
+  <span class="input-group-btn">
+    <button type="button" class="btn btn-warning">検索</button>
+  </span>
+</div>
+
+<div class="topic-list">
+  <%= link_to "新着記事" ,"root_path",class:"topic_tag" %>
+  <%= link_to "人気記事" ,"root_path",class:"topic_tag" %>
+  <%= link_to "オススメ" ,"root_path",class:"topic_tag" %>
+</div>
+
+<div class="topic_content">
+  <div class="row">
+    <% @topics.each do |topic| %>
+    <div class="col-md-4">
+      <a href="/homes/<%= topic.id %>">
+      <div class="card">
+      <%= image_tag "#{topic.image}",id:"card_image" %>
+      <div class="card-body">
+        <p class="topic_genre"><i class="fas fa-hashtag"> <%= topic.genre %></i></p>
+        <p class="topic_title"><%= topic.title %></p>
+        <p class="topic_shop_name"><i class="fas fa-store"> <%= topic.shop.name %></i></p>
+        <p class="topic_address"><i class="fas fa-map-marker-alt"></i> <%= topic.shop.address %></p></div>
+        <p class="topic_day"><%= topic.created_at.to_s(:datetime_jp) %></p>
+      </div>
+      </a>
+    </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="topic_page">
+  <%= paginate @topics %>
+</div>

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,0 +1,27 @@
+<div class="topic_show">
+  <p><%= @topic.created_at.to_s(:datetime_jp) %></p>
+  <h2><%= @topic.title %></h2>
+  <div class="show_image">
+    <%= image_tag "#{@topic.image}",id:"top_image"%>
+  </div>
+  <p><%= markdown(@topic.content).html_safe %></p>
+  <h2>お店情報</h2>
+  <div class="row">
+    <div class="col-md-6">
+      <iframe src="<%= @topic.shop.map %>" <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3273.9637811979896!2d134.93509731566832!3d34.857137382330706!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35552de92e9631f1%3A0x80fe880b602b0b19!2z5ZKM5rCRIOWwj-mHjuW6lw!5e0!3m2!1sja!2sjp!4v1595936972236!5m2!1sja!2sjp" width="600" height="560" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+    </div>
+    <div class="col-md-6">
+      <ul>
+        <%= image_tag "#{@topic.shop.shop_image}", id:"show_shop_image" %>
+        <li>店名：<%= @topic.shop.name %></li>
+        <li>一言：<%= @topic.shop.introduce %></li>
+        <li>住所：<%= @topic.shop.address %></li>
+        <li>アクセル：<%= @topic.shop.access %></li>
+        <li>電話番号：<a href="tel:<%= @topic.shop.number %>"><%= @topic.shop.number %></a></li>
+        <li>営業時間：<%= @topic.shop.time %></li>
+        <li>定休日：<%= @topic.shop.rest %></li>
+        <li>テイクアウト：<%= @topic.shop.takeout %></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>OnoGourmet</title>
+    <title>おのグルメ｜小野市のグルメに特化した町おこしサイト｜</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
   </head>
 
   <body>
   <header>
     <%= render 'homes/header' %>
+    <%= render 'homes/header_image' %>
   </header>
   <main>
     <%= yield %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module OnoGourmet
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:datetime_jp] = '%Y年 %m月%d日'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>
+      truncate: "..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   root to: "homes#index"
+  resources :homes
 end


### PR DESCRIPTION
**実装内容**
- トピックを1列にカードを3個、3列並べた
- ページネーション実装
- 詳細ページ実装
- 日付を日本時間に変更
- CSSで見た目を整える

**参考文献**
- https://qiita.com/tomo_k09/items/e4f19947d35890500492