### PR TITLE
トピック詳細ページの右にサイドバーを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,7 +30,7 @@ main {
 
 // コンテンツの幅指定
 .topic_center{
-  max-width: 1200px;
+  max-width: 1100px;
   margin: 30px auto;
 }
 // ヘッダーの画像の大きさ
@@ -162,8 +162,50 @@ main {
 }
 // トピック詳細の画像（子要素）
 .topic_show #top_image{
-  width: 1200px;
+  width: 100%;
   height: 600px;
+}
+// トピックのカード
+.topic_show .card{
+  margin: 40px 0 40px 50px;
+}
+// トピック「人気ランキング」
+.topic_show h4{
+  font-weight: bold;
+  margin: 40px 0 30px 60px;
+  font-size: 19px;
+}
+// トピックの順位
+.topic_show h3{
+  margin-left: 50px;
+  border: solid 1px black;
+  border-radius: 20px;
+}
+// トピックのAタグ
+.topic_show a{
+  text-decoration: none;
+  color: black;
+}
+// トピックのジャンル
+.topic_show .topic_genre{
+  font-size: 10px;
+  margin: -10px 0 10px -10px;
+}
+// トピックのタイトル
+.topic_show .topic_title{
+  font-size: 14px;
+  font-weight: bold;
+}
+// トピックの表示回数
+.topic_show .topic_view{
+  text-align: right;
+  margin: -35px 20px 10px 0;
+  display: inline;
+}
+//トピック画像
+.topic_show #card_image{
+  width: 200px;
+  height: 150px;
 }
 // トピック詳細のお店画像
 .topic_show #show_shop_image{
@@ -259,7 +301,7 @@ main {
 }
 .shop_content .card{
   border: solid 1px black;
-  width: 380px;
+  width: 360px;
   height: 490px;
   margin: 20px;
 }
@@ -271,7 +313,7 @@ main {
   margin: -10px 0 10px 0;
 }
 .shop_content #card_image{
-  width: 378px;
+  width: 358px;
   height: 200px;
 }
 .shop_content .card-body li{

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,5 +1,5 @@
 class TopicsController < ApplicationController
-   impressionist :actions => [:show,:index]
+   impressionist :actions => [:show], :unique => [:impressionable_id, :ip_address]
 
   def index
     @search = Topic.ransack(params[:q])
@@ -8,6 +8,7 @@ class TopicsController < ApplicationController
 
   def show
     @topic = Topic.find(params[:id])
-    impressionist(@topic, nil, unique: [:session_hash])
+    @topics = Topic.all.order(impressions_count: 'DESC').limit(5)
+    impressionist(@topic, nil, unique: [:impressionable_id, :ip_address])
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2,5 +2,5 @@ class Topic < ApplicationRecord
   belongs_to :shop
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
-  is_impressionable
+  is_impressionable counter_cache: true
 end

--- a/app/views/topics/_content.html.erb
+++ b/app/views/topics/_content.html.erb
@@ -9,7 +9,8 @@
         <p class="topic_genre"><i class="fas fa-hashtag"> <%= topic.genre %></i></p>
         <p class="topic_title"><%= topic.title %></p>
         <p class="topic_shop_name"><i class="fas fa-store"> <%= topic.shop.name %></i></p>
-        <p class="topic_address"><i class="fas fa-map-marker-alt"></i> <%= topic.shop.address %></p></div>
+        <p class="topic_address"><i class="fas fa-map-marker-alt"></i> <%= topic.shop.address %></p>
+      </div>
         <p class="topic_day"><%= topic.created_at.to_s(:datetime_jp) %></p>
         <p class="topic_view"><%= topic.impressionist_count %> <%= topic.impressionist_count <= 1 ? "view" : "views" %></p>
       </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,29 +1,50 @@
 <div class="topic_center">
   <div class="topic_show">
-    <p><%= @topic.created_at.to_s(:datetime_jp) %></p>
-    <h2><%= @topic.title %></h2>
-    <div class="show_image">
-      <%= image_tag "#{@topic.image}",id:"top_image"%>
-    </div>
-    <p><%= markdown(@topic.content).html_safe %></p>
-    <h2>お店情報</h2>
     <div class="row">
-      <div class="col-md-6">
-        <iframe src="<%= @topic.shop.map %>" <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3273.9637811979896!2d134.93509731566832!3d34.857137382330706!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35552de92e9631f1%3A0x80fe880b602b0b19!2z5ZKM5rCRIOWwj-mHjuW6lw!5e0!3m2!1sja!2sjp!4v1595936972236!5m2!1sja!2sjp" width="600" height="560" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+      <div class="col-md-9">
+        <p><%= @topic.created_at.to_s(:datetime_jp) %></p>
+        <h2><%= @topic.title %></h2>
+        <div class="show_image">
+          <%= image_tag "#{@topic.image}",id:"top_image"%>
+        </div>
+        <p><%= markdown(@topic.content).html_safe %></p>
+        <h2>お店情報</h2>
+        <div class="row">
+          <div class="col-md-6">
+            <iframe src="<%= @topic.shop.map %>" <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3273.9637811979896!2d134.93509731566832!3d34.857137382330706!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x35552de92e9631f1%3A0x80fe880b602b0b19!2z5ZKM5rCRIOWwj-mHjuW6lw!5e0!3m2!1sja!2sjp!4v1595936972236!5m2!1sja!2sjp" width="415" height="600" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+          </div>
+          <div class="col-md-6">
+            <ul>
+              <%= image_tag "#{@topic.shop.shop_image}", id:"show_shop_image" %>
+              <li>店名：<%= @topic.shop.name %></li>
+              <li>一言：<%= @topic.shop.introduce %></li>
+              <li>住所：<%= @topic.shop.address %></li>
+              <li>アクセル：<%= @topic.shop.access %></li>
+              <li>電話番号：<a href="tel:<%= @topic.shop.number %>"><%= @topic.shop.number %></a></li>
+              <li>営業時間：<%= @topic.shop.time %></li>
+              <li>定休日：<%= @topic.shop.rest %></li>
+              <li>テイクアウト：<%= @topic.shop.takeout %></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="col-md-6">
-        <ul>
-          <%= image_tag "#{@topic.shop.shop_image}", id:"show_shop_image" %>
-          <li>店名：<%= @topic.shop.name %></li>
-          <li>一言：<%= @topic.shop.introduce %></li>
-          <li>住所：<%= @topic.shop.address %></li>
-          <li>アクセル：<%= @topic.shop.access %></li>
-          <li>電話番号：<a href="tel:<%= @topic.shop.number %>"><%= @topic.shop.number %></a></li>
-          <li>営業時間：<%= @topic.shop.time %></li>
-          <li>定休日：<%= @topic.shop.rest %></li>
-          <li>テイクアウト：<%= @topic.shop.takeout %></li>
-        </ul>
-      </div>
-    </div>
+
+
+      <div class="col-md-3">
+        <h4>人気記事ランキンング</h4>
+          <% @topics.each.with_index(1) do |topic, i| %>
+          <h3  style="text-align:center";><%= i %></h3>
+            <a href="/topics/<%= topic.id %>">
+            <div class="card">
+            <%= image_tag "#{topic.image}",id:"card_image" %>
+            <div class="card-body">
+              <p class="topic_genre"><i class="fas fa-hashtag"> <%= topic.genre %></i></p>
+              <p class="topic_title"><%= topic.title %></p>
+            </div>
+              <p class="topic_view"><%= topic.impressionist_count %> <%= topic.impressionist_count <= 1 ? "view" : "views" %></p>
+            </div>
+            </a>
+          <% end %>
+
   </div>
 </div>

--- a/db/migrate/20200817041245_add_impressions_count_to_topic.rb
+++ b/db/migrate/20200817041245_add_impressions_count_to_topic.rb
@@ -1,0 +1,5 @@
+class AddImpressionsCountToTopic < ActiveRecord::Migration[6.0]
+  def change
+    add_column :topics, :impressions_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_09_235915) do
+ActiveRecord::Schema.define(version: 2020_08_17_041245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2020_08_09_235915) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "shop_id"
+    t.integer "impressions_count", default: 0
     t.index ["shop_id"], name: "index_topics_on_shop_id"
   end
 


### PR DESCRIPTION
**実装内容**
- トピック詳細ページにサイドバーを追加
- impressionistの計測をIPアドレスに変更
- CSSである程度デザインを整える
- 全ページの横幅を少し狭くした